### PR TITLE
blocked issues

### DIFF
--- a/.github/workflows/manage-issue.yml
+++ b/.github/workflows/manage-issue.yml
@@ -1,0 +1,11 @@
+name: "Auto Manage Issue Blockers"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  
+jobs:
+  call-issue-blocker:
+    uses: JamesonRGrieve/Workflows/.github/workflows/issue-blocker-reusuable.yml@main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,20 @@
 [submodule "src/lib/next-log"]
 path = src/lib/next-log
 url = https://github.com/JamesonRGrieve/next-log.git
+	branch = main
 [submodule "src/components/auth"]
 path = src/components/auth
 url = https://github.com/JamesonRGrieve/auth.git
+	branch = main
 [submodule "src/components/appwrapper"]
 path = src/components/appwrapper
 url = https://github.com/JamesonRGrieve/appwrapper.git
+	branch = main
 [submodule "src/components/dynamic-form"]
 path = src/components/dynamic-form
 url = https://github.com/JamesonRGrieve/dynamic-form.git
+	branch = main
 [submodule "src/lib/zod2gql"]
 path = src/lib/zod2gql
 url = https://github.com/JamesonRGrieve/zod2gql.git
+	branch = main


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We have wrote a script for Blocked  Issues and committed that file in "git@github.com:JamesonRGrieve/Workflows.git"
# Description
We need to implement intelligent management of blocked issues in Projects V2 by automatically maintaining the relationship between blocking issues and project status. The system should dynamically update the "Blocked by Issue(s)" field and corresponding status based on the state of blocking issues, ensuring that project dependencies are accurately reflected and managed.

## Motivation and Context

The automation begins by scanning all open issues and identifying any that contain a "Blocked by Issue(s)" field or comment referencing other issues (e.g., #123, #456). For each referenced issue, it checks whether the issue is still open or has been closed. If an issue is closed, its reference is removed from the "Blocked by" list. The updated list is then written back to the comment or field. If no blockers remain and the issue is currently marked as "Blocked," the system attempts to restore the previous status. If a valid previous status is found (such as "In Progress" or "In Review"), it is reinstated. However, if no previous status exists—meaning the issue went directly to "Blocked"—the status defaults to "To-Do."

## How has this been tested?

Created Tickets in my local GitHub and check all Acceptance criteria

